### PR TITLE
Prosody 0.11 help documentation

### DIFF
--- a/caas-web/src/main/resources/help/prosody/xep0313muc.md
+++ b/caas-web/src/main/resources/help/prosody/xep0313muc.md
@@ -1,5 +1,5 @@
 * Make sure your server has v0.10+
-* Add the community module [mod\_mam\_muc](https://modules.prosody.im/mod_mam_muc).
+* Add the community module [mod\_mam\_muc](https://modules.prosody.im/mod_mam_muc) if you have <v0.11 or mod\_muc\_mam for =>v0.11.
 * As shown in the documentation, add a modules\_enabled with this module just after
 the MUC `Component` line in your configuration
 

--- a/caas-web/src/main/resources/help/prosody/xep0398.md
+++ b/caas-web/src/main/resources/help/prosody/xep0398.md
@@ -1,5 +1,5 @@
-* Not currently supported in a released version of Prosody
-* trunk/v0.11 (unreleased): Enable the community module [mod\_profile](https://modules.prosody.im/mod_profile)
+* Make sure the server has v0.11+
+* trunk/v0.11 : Enable the community module [mod\_profile](https://modules.prosody.im/mod_profile) or for v0.11: [mod\_pep_\vcard_\avatar](https://modules.prosody.im/mod_pep_vcard_avatar)
 
 Note: This module does not come with default prosody installation.
 However, it can be set up by adding a community module.

--- a/caas-web/src/main/resources/help/prosody/xep0398.md
+++ b/caas-web/src/main/resources/help/prosody/xep0398.md
@@ -1,5 +1,5 @@
 * Make sure the server has v0.11+
-* trunk/v0.11 : Enable the community module [mod\_profile](https://modules.prosody.im/mod_profile) or for v0.11: [mod\_pep_\vcard_\avatar](https://modules.prosody.im/mod_pep_vcard_avatar)
+* trunk/v0.11 : Enable the community module [mod\_profile](https://modules.prosody.im/mod_profile) or for v0.11: [mod\_pep\_vcard\_avatar](https://modules.prosody.im/mod_pep_vcard_avatar)
 
 Note: This module does not come with default prosody installation.
 However, it can be set up by adding a community module.


### PR DESCRIPTION
Prosody 0.11 has been released two days ago.

Changes: 
* you have to use mod_muc_mam instead of mod_mam_muc
* mod_profile makes caas raise `rocks.xmpp.core.stanza.StanzaException: item-not-found`, mod_pep_vcard_avatar works fine

https://prosody.im/doc/release/0.11.0#upgrade_notes
