### PR TITLE
Require open access to host-meta file to pass test

### DIFF
--- a/caas-app/src/main/java/im/conversations/compliance/xmpp/tests/AlternateConnections.java
+++ b/caas-app/src/main/java/im/conversations/compliance/xmpp/tests/AlternateConnections.java
@@ -15,6 +15,7 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -44,8 +45,12 @@ public class AlternateConnections extends AbstractTest {
     }
 
     private static boolean discoverAndTestAltConnections(final String domain, final boolean json, final boolean https) {
-        try (final InputStream is = new URL(https ? "https" : "http", domain, "/.well-known/host-meta" + (json ? ".json" : "")).openStream()) {
-            return json ? testAltConnectionsFromJson(is) : testAltConnectionsFromXml(is);
+        try {
+            URL url = new URL(https ? "https" : "http", domain, "/.well-known/host-meta" + (json ? ".json" : ""));
+            URLConnection connection = url.openConnection();
+            try (final InputStream is = connection.getInputStream()) {
+                return json ? testAltConnectionsFromJson(is) : testAltConnectionsFromXml(is);
+            }
         } catch (Throwable throwable) {
             return false;
         }

--- a/caas-app/src/main/java/im/conversations/compliance/xmpp/tests/AlternateConnections.java
+++ b/caas-app/src/main/java/im/conversations/compliance/xmpp/tests/AlternateConnections.java
@@ -46,8 +46,11 @@ public class AlternateConnections extends AbstractTest {
 
     private static boolean discoverAndTestAltConnections(final String domain, final boolean json, final boolean https) {
         try {
-            URL url = new URL(https ? "https" : "http", domain, "/.well-known/host-meta" + (json ? ".json" : ""));
-            URLConnection connection = url.openConnection();
+            final URL url = new URL(https ? "https" : "http", domain, "/.well-known/host-meta" + (json ? ".json" : ""));
+            final URLConnection connection = url.openConnection();
+            if (!"*".equals(connection.getHeaderField("Access-Control-Allow-Origin"))) {
+                return false;
+            }
             try (final InputStream is = connection.getInputStream()) {
                 return json ? testAltConnectionsFromJson(is) : testAltConnectionsFromXml(is);
             }

--- a/caas-web/src/main/resources/help/ejabberd/xep0156.md
+++ b/caas-web/src/main/resources/help/ejabberd/xep0156.md
@@ -1,1 +1,3 @@
 Look at the [Examples Section](https://xmpp.org/extensions/xep-0156.html#httpexamples) of XEP-0156 and create appropriate files for your server. Only one of `host-meta` and `host-meta.json` is required to pass this test. However it is recommended to create both.
+
+To pass this test the host-meta files should additionally have [`Access-Control-Allow-Origin: *`](https://xmpp.org/extensions/xep-0156.html#impl) response header so that the file contents can be read by web clients.

--- a/caas-web/src/main/resources/help/openfire/xep0156.md
+++ b/caas-web/src/main/resources/help/openfire/xep0156.md
@@ -1,1 +1,3 @@
 Look at the [Examples Section](https://xmpp.org/extensions/xep-0156.html#httpexamples) of XEP-0156 and create appropriate files for your server. Only one of `host-meta` and `host-meta.json` is required to pass this test. However it is recommended to create both.
+
+To pass this test the host-meta files should additionally have [`Access-Control-Allow-Origin: *`](https://xmpp.org/extensions/xep-0156.html#impl) response header so that the file contents can be read by web clients.

--- a/caas-web/src/main/resources/help/prosody/xep0156.md
+++ b/caas-web/src/main/resources/help/prosody/xep0156.md
@@ -1,1 +1,3 @@
 Look at the [Examples Section](https://xmpp.org/extensions/xep-0156.html#httpexamples) of XEP-0156 and create appropriate files for your server. Only one of `host-meta` and `host-meta.json` is required to pass this test. However it is recommended to create both.
+
+To pass this test the host-meta files should additionally have [`Access-Control-Allow-Origin: *`](https://xmpp.org/extensions/xep-0156.html#impl) response header so that the file contents can be read by web clients.


### PR DESCRIPTION
XEP-0156 [suggests][0] using `Access-Control-Allow-Origin: *` response header on host-meta files so that the connection methods can be discovered by web clients.

This change checks for the response header and passes the test only if at least one of the host-meta files has this header set.

See #49.

(I'm planning to add further PRs to this as mentioned in #49 but if you don't mind I'll keep the PRs small to be easy for review).

[0]: https://xmpp.org/extensions/xep-0156.html#impl