### PR TITLE
Correct namespace and prefix used in stream opening

### DIFF
--- a/caas-app/src/main/java/im/conversations/compliance/xmpp/tests/XmppOverTls.java
+++ b/caas-app/src/main/java/im/conversations/compliance/xmpp/tests/XmppOverTls.java
@@ -52,7 +52,7 @@ public class XmppOverTls extends AbstractTest {
                     }
                     BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
                     BufferedWriter bufferedWriter = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream()));
-                    bufferedWriter.write("<?xml version='1.0'?><stream to='"+domain+"' version='1.0' xml:lang='en' xmlns='jabber:client xmlns:stream='http://etherx.jabber.org/streams'>");
+                    bufferedWriter.write("<?xml version='1.0'?><stream:stream to='"+domain+"' version='1.0' xml:lang='en' xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams'>");
                     bufferedWriter.flush();
                     char[] buffer = new char[21];
                     if (bufferedReader.read(buffer) != buffer.length) {


### PR DESCRIPTION
Correct XML used to open stream to make it conformant with https://xmpp.org/rfcs/rfc6120.html#streams-ns-content