### PR TITLE
XEP-0156: Add CORS examples for HTTP servers

### DIFF
--- a/caas-web/src/main/resources/help/ejabberd/xep0156.md
+++ b/caas-web/src/main/resources/help/ejabberd/xep0156.md
@@ -1,3 +1,25 @@
 Look at the [Examples Section](https://xmpp.org/extensions/xep-0156.html#httpexamples) of XEP-0156 and create appropriate files for your server. Only one of `host-meta` and `host-meta.json` is required to pass this test. However it is recommended to create both.
 
 To pass this test the host-meta files should additionally have [`Access-Control-Allow-Origin: *`](https://xmpp.org/extensions/xep-0156.html#impl) response header so that the file contents can be read by web clients.
+
+Nginx: Example code to add to server block:
+
+```
+location /.well-known/host-meta {
+    default_type 'application/xrd+xml';
+    add_header Access-Control-Allow-Origin '*' always;
+}
+
+location /.well-known/host-meta.json {
+    default_type 'application/jrd+json';
+    add_header Access-Control-Allow-Origin '*' always;
+}
+```
+
+Apache: Example code to add to `conf/httpd.conf` file:
+
+```
+<Location ~ "/\.well-known/host-meta(\.json)?">
+    Header set Access-Control-Allow-Origin "*"
+</Location>
+```

--- a/caas-web/src/main/resources/help/openfire/xep0156.md
+++ b/caas-web/src/main/resources/help/openfire/xep0156.md
@@ -1,3 +1,25 @@
 Look at the [Examples Section](https://xmpp.org/extensions/xep-0156.html#httpexamples) of XEP-0156 and create appropriate files for your server. Only one of `host-meta` and `host-meta.json` is required to pass this test. However it is recommended to create both.
 
 To pass this test the host-meta files should additionally have [`Access-Control-Allow-Origin: *`](https://xmpp.org/extensions/xep-0156.html#impl) response header so that the file contents can be read by web clients.
+
+Nginx: Example code to add to server block:
+
+```
+location /.well-known/host-meta {
+    default_type 'application/xrd+xml';
+    add_header Access-Control-Allow-Origin '*' always;
+}
+
+location /.well-known/host-meta.json {
+    default_type 'application/jrd+json';
+    add_header Access-Control-Allow-Origin '*' always;
+}
+```
+
+Apache: Example code to add to `conf/httpd.conf` file:
+
+```
+<Location ~ "/\.well-known/host-meta(\.json)?">
+    Header set Access-Control-Allow-Origin "*"
+</Location>
+```

--- a/caas-web/src/main/resources/help/prosody/xep0156.md
+++ b/caas-web/src/main/resources/help/prosody/xep0156.md
@@ -1,3 +1,25 @@
 Look at the [Examples Section](https://xmpp.org/extensions/xep-0156.html#httpexamples) of XEP-0156 and create appropriate files for your server. Only one of `host-meta` and `host-meta.json` is required to pass this test. However it is recommended to create both.
 
 To pass this test the host-meta files should additionally have [`Access-Control-Allow-Origin: *`](https://xmpp.org/extensions/xep-0156.html#impl) response header so that the file contents can be read by web clients.
+
+Nginx: Example code to add to server block:
+
+```
+location /.well-known/host-meta {
+    default_type 'application/xrd+xml';
+    add_header Access-Control-Allow-Origin '*' always;
+}
+
+location /.well-known/host-meta.json {
+    default_type 'application/jrd+json';
+    add_header Access-Control-Allow-Origin '*' always;
+}
+```
+
+Apache: Example code to add to `conf/httpd.conf` file:
+
+```
+<Location ~ "/\.well-known/host-meta(\.json)?">
+    Header set Access-Control-Allow-Origin "*"
+</Location>
+```


### PR DESCRIPTION
This change adds snippets that can be pasted by HTTP server administrators into their server's configuration files to add appropriate CORS headers for `/.well-known/host-meta` files.