### PR TITLE
XEP-0398 on ejabberd: add required mod_vcard_xupdate

### DIFF
--- a/caas-web/src/main/resources/help/ejabberd/xep0398.md
+++ b/caas-web/src/main/resources/help/ejabberd/xep0398.md
@@ -1,1 +1,8 @@
-* Configure mod_avatar
+* Add modules mod_avatar and mod_vcard_xupdate to modules list
+```
+modules:
+    ...
+    mod_avatar: {}
+    mod_vcard_xupdate: {}
+
+```


### PR DESCRIPTION
I needed to enable mod_vcard_xupdate as well to pass the test for XEP-0398.