### PR TITLE
fix indent in mam explanation

### DIFF
--- a/caas-web/src/main/resources/help/ejabberd/xep0313muc.md
+++ b/caas-web/src/main/resources/help/ejabberd/xep0313muc.md
@@ -4,11 +4,11 @@
 ```
 modules:
     ...
-     mod_mam:
+    mod_mam:
         default: always
     mod_muc:
-    ...
-    default_room_options:
-        mam: true
+        ...
+        default_room_options:
+            mam: true
     ...
 ```


### PR DESCRIPTION
The current description of the MAM issue contians misleading spacing.

mod_mam has one extra space.
The default_room_options is a sub-option of mod_muc and should be indented accordingly.