### PR TITLE
Display only public servers in search bar

### DIFF
--- a/caas-web/src/main/java/im/conversations/compliance/web/Controller.java
+++ b/caas-web/src/main/java/im/conversations/compliance/web/Controller.java
@@ -26,7 +26,7 @@ public class Controller {
     private static final Gson gson = JsonReader.gson;
 
     public static TemplateViewRoute getRoot = (request, response) -> {
-        List<Server> servers = DBOperations.getServers(false);
+        List<Server> servers = DBOperations.getServers(true);
         HashMap<String, Object> model = new HashMap<>();
         model.put("servers", gson.toJson(servers.stream().map(Server::getDomain).collect(Collectors.toList())));
         List<String> compliantServerNames = DBOperations.getCompliantServers();


### PR DESCRIPTION
Until now all servers (i.e. also servers that were added as non-public servers) have been listed in the search suggestions of the search bar.
Now only servers from the public list are displayed.