### PR TITLE
Fix read() in XmppOverTls test

### DIFF
--- a/caas-app/src/main/java/im/conversations/compliance/xmpp/tests/XmppOverTls.java
+++ b/caas-app/src/main/java/im/conversations/compliance/xmpp/tests/XmppOverTls.java
@@ -56,8 +56,13 @@ public class XmppOverTls extends AbstractTest {
                     bufferedWriter.write("<?xml version='1.0'?><stream:stream to='"+domain+"' version='1.0' xml:lang='en' xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams'>");
                     bufferedWriter.flush();
                     char[] buffer = new char[21];
-                    if (bufferedReader.read(buffer) != buffer.length) {
-                        return false;
+                    int remainingChars = buffer.length;
+                    while (remainingChars > 0) {
+                        int charsRead = bufferedReader.read(buffer, buffer.length - remainingChars, remainingChars);
+                        if (charsRead == -1) {
+                            return false;
+                        }
+                        remainingChars -= charsRead;
                     }
                     final String serverOpening = new String(buffer);
                     socket.close();


### PR DESCRIPTION
The code assumed that the read() method would always either fill the
buffer or otherwise there is an error. While it is in practice very
likely that this is the case, it is fragile to rely on that behavior.

Instead the code should handle the case where read() may only return a
few chars, but not enough to fill the buffer.