### PR TITLE
Suggest refreshing page for more servers

### DIFF
--- a/caas-web/src/main/resources/spark/template/freemarker/root.ftl
+++ b/caas-web/src/main/resources/spark/template/freemarker/root.ftl
@@ -23,7 +23,7 @@
     </div>
     <#if recommendations?has_content>
         <div id="recommended_servers">
-        <h3>Randomly suggested compliant servers</h3>
+        <h3>Randomly suggested compliant servers (Refresh page to see more)</h3>
         <#list recommendations as recommendation>
             <div class="chip clickable" onclick="location.href='/server/${recommendation}'">
             ${recommendation}


### PR DESCRIPTION
Only 5 servers are listed by default and the listed domains may not interesting to a user. Explicitly inform more servers can be seen by refreshing the page.